### PR TITLE
Add dark mode toggle

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,6 +22,7 @@ import {
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
+import { ThemeToggle } from "@/components/theme-toggle"
 
 export default function Portfolio() {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
@@ -110,15 +111,18 @@ export default function Portfolio() {
               ))}
             </div>
 
-            {/* Mobile Menu Button */}
-            <Button
-              variant="ghost"
-              size="icon"
-              className="md:hidden text-black hover:bg-gray-100"
-              onClick={() => setIsMenuOpen(!isMenuOpen)}
-            >
-              {isMenuOpen ? <X /> : <Menu />}
-            </Button>
+            <div className="flex items-center gap-2">
+              <ThemeToggle />
+              {/* Mobile Menu Button */}
+              <Button
+                variant="ghost"
+                size="icon"
+                className="md:hidden text-black hover:bg-gray-100"
+                onClick={() => setIsMenuOpen(!isMenuOpen)}
+              >
+                {isMenuOpen ? <X /> : <Menu />}
+              </Button>
+            </div>
           </div>
         </nav>
 
@@ -140,6 +144,7 @@ export default function Portfolio() {
                   {item}
                 </button>
               ))}
+              <ThemeToggle />
             </div>
           </motion.div>
         )}

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useTheme } from 'next-themes'
+import { useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Sun, Moon } from 'lucide-react'
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => setMounted(true), [])
+
+  if (!mounted) return null
+
+  const toggleTheme = () => {
+    setTheme(theme === 'light' ? 'dark' : 'light')
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleTheme}
+      aria-label="Toggle theme"
+    >
+      {theme === 'light' ? <Moon className="w-5 h-5" /> : <Sun className="w-5 h-5" />}
+    </Button>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add ThemeToggle component for switching themes
- embed theme toggle in navigation bar and mobile menu

## Testing
- `pnpm install`
- `pnpm run lint` *(fails: interactive eslint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6840169ca3488321b0257b43806f8204